### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ python -m spacy download en_core_web_lg
 From the source code:
 ```
 git clone https://github.com/TQRG/secomlint.git
-cd secomlint
+cd secomlint/secomlint
 pip install .
 python -m spacy download en_core_web_lg
 ```


### PR DESCRIPTION
To be able to follow the install guide, it is necessary to use the 'cd' command the way I have changed it in README.md; else, it will throw an error.